### PR TITLE
Config folder search strategy for unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,7 @@ add_executable(gta3sc
 
 target_link_libraries(gta3sc cppformat antlr3 stdc++fs)
 
+add_custom_command(TARGET gta3sc POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/config $<TARGET_FILE_DIR:gta3sc>/config)
+
 #install(TARGETS gta3sc RUNTIME DESTINATION bin)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "decompiler.hpp"
 #include "codegen.hpp"
 #include "program.hpp"
+#include "system.hpp"
 #include "cpp/argv.hpp"
 
 int compile(fs::path input, fs::path output, const Options& options, const Commands& commands);
@@ -163,6 +164,9 @@ int main(int argc, char** argv)
             return EXIT_FAILURE;
         }
     }
+
+    fs::path conf_path = config_path();
+    fprintf(stdout, "Using '%s' as configuration path\n", conf_path.string().c_str());
 
     try
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
                 }
                 else
                 {
-                    throw invalid_opt("arbitrary config names not supported yet");
+                    throw invalid_opt("arbitrary config names not supported yet. Must be 'gta3', 'gtavc' or 'gtasa'");
                 }
             }
             else if(optflag(argv, "half-float", &flag))

--- a/src/stdinc.h
+++ b/src/stdinc.h
@@ -1,5 +1,6 @@
 #pragma once
 #define _CRT_SECURE_NO_WARNINGS
+#include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 #include <memory>

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -2,7 +2,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#else
 #endif
 
 static fs::path find_config_path()
@@ -17,6 +16,30 @@ static fs::path find_config_path()
         path /= L"../../.."; // TODO remove me, needed only when debug building
         path /= L"config";
         return path;
+    }
+    throw std::runtime_error("find_config_path failed");
+#elif defined(__unix__)
+    const char* home_path = std::getenv("HOME");
+    std::vector<fs::path> search_path;
+    // Search path for unix, ordered by priority:
+    {
+        // In folder of the binary (temporary installations etc.)
+        search_path.emplace_back("./config");
+        // Home folder
+        if(home_path != NULL)
+        {
+            search_path.emplace_back(fs::path(home_path) / ".local/share/gta3sc/config");
+        }
+        // Generic installation
+        search_path.emplace_back("/usr/share/gta3sc/config");
+    }
+
+    for(auto& path : search_path)
+    {
+        if(fs::is_directory(path))
+        {
+            return path;
+        }
     }
     throw std::runtime_error("find_config_path failed");
 #else


### PR DESCRIPTION
Included in this PR:

- Print used config folder (Possible todo: add config name already?).
- Search for a config folder on unix, from minimal installation to full blown installation
- Let cmake copy config folder to the build directory
- Provide a more helpful error message if no valid config name is given (\<arbitrary config names not supported yet. *Must be 'gta3', 'gtavc' or 'gtasa'*\>)

I did not check what POSIX has to say about this and I'm not sure about the `_unix_` defined check either. Works *shrugs*