### PR TITLE
Fix mingw: strcasecmp and strncasecmp redifinition

### DIFF
--- a/src/cpp/icompare.hpp
+++ b/src/cpp/icompare.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <cstring>
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 inline int strcasecmp(const char* a, const char* b)
 {
     return _stricmp(a, b);
@@ -14,7 +14,7 @@ inline int strncasecmp(const char* a, const char* b, size_t count)
 {
     return _strnicmp(a, b, count);
 }
-#elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#elif defined (__unix__) || (__MINGW32__) || (defined (__APPLE__) && defined (__MACH__))
     // Already has strcasecmp and strncasecmp
 #else
 #   error


### PR DESCRIPTION
mingw defines the _WIN32 macro as well, which here causes it to define strcasecmp and strncasecmp since (I assume) MSVS doesn't implement these functions. However mingw does already implement these functions.
This fixes #127