### PR TITLE
Fix release builds in mingw, gcc and clang

### DIFF
--- a/src/cpp/contracts.hpp
+++ b/src/cpp/contracts.hpp
@@ -49,6 +49,7 @@ struct unreachable_exception : std::runtime_error
 
 #define Expects(cond)     void(0)
 #define Ensures(cond)     void(0)
-#define Unreachable()     (std::terminate(), throw 0)
+#define Unreachable()     \
+    (throw std::runtime_error("Unreachable code reached"))
 
 #endif


### PR DESCRIPTION
mingw, gcc and clang compilers don't seem to like using (std::terminate(), throw 0) rvalue, but they are okay with (throw std::runtime_error()) as an rvalue.
This fixes #129