### PR TITLE
Add support for `IFNOT` and `WHILENOT`

### DIFF
--- a/config/gta3/cleo.xml
+++ b/config/gta3/cleo.xml
@@ -392,7 +392,7 @@
     <Command ID="0xa9a" Name="OPEN_FILE" Hash="0xd4269fc0">
       <Args>
         <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
-        <Arg Type="INT"/>
+        <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
         <Arg Type="INT" Out="true" Entity="FILE"/>
       </Args>
     </Command>

--- a/config/gta3/commandline.txt
+++ b/config/gta3/commandline.txt
@@ -7,6 +7,7 @@
 -fno-switch
 -fno-arrays
 -fno-const
+-fifnot
 -fno-scope-then-label
 -fno-underscore-idents
 -fno-streamed-scripts

--- a/config/gta3/commands.xml
+++ b/config/gta3/commands.xml
@@ -3564,7 +3564,7 @@
         <Arg Type="FLOAT" Desc="Z Coord"/>
         <Arg Type="FLOAT"/>
         <Arg Type="FLOAT"/>
-        <Arg Type="INT"/>
+        <Arg Type="INT" Enum="GARAGE"/>
         <Arg Type="INT" Out="true" Entity="GARAGE"/>
       </Args>
     </Command>

--- a/config/gta3/commands.xml
+++ b/config/gta3/commands.xml
@@ -2108,7 +2108,7 @@
         <Arg Type="INT" Ref="true" AllowConst="false" AllowLocalVar="false"/>
       </Args>
     </Command>
-    <Command ID="0x150" Name="DISPLAY_ONSCREEN_COUNTER" Supported="false">
+    <Command ID="0x150" Name="DISPLAY_ONSCREEN_COUNTER">
       <Args>
         <Arg Type="INT" Ref="true" AllowConst="false" AllowLocalVar="false"/>
         <Arg Type="INT" Enum="COUNTER_DISPLAY"/>
@@ -7237,7 +7237,7 @@
         <Arg Type="FLOAT" Desc="Z Coord" Out="true"/>
       </Args>
     </Command>
-    <Command ID="0x464" Name="ATTACH_CHAR_TO_CAR">
+    <Command ID="0x464" Name="ATTACH_CHAR_TO_CAR" Supported="false">
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
         <Arg Type="INT" Entity="CAR"/>
@@ -7249,7 +7249,7 @@
         <Arg Type="INT" Enum="WEAPONTYPE"/>
       </Args>
     </Command>
-    <Command ID="0x465" Name="DETACH_CHAR_FROM_CAR">
+    <Command ID="0x465" Name="DETACH_CHAR_FROM_CAR" Supported="false">
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
       </Args>
@@ -7353,7 +7353,7 @@
         <Arg Type="INT" Desc="Bool"/>
       </Args>
     </Command>
-    <Command ID="0x473" Name="LOCATE_CHAR_IN_CAR_OBJECT_2D" Supported="false">
+    <Command ID="0x473" Name="LOCATE_CHAR_IN_CAR_OBJECT_2D">
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
         <Arg Type="INT" Entity="OBJECT"/>
@@ -7362,17 +7362,7 @@
         <Arg Type="INT" Desc="Bool"/>
       </Args>
     </Command>
-    <Command ID="0x474" Name="LOCATE_CHAR_ANY_MEANS_OBJECT_3D" Supported="false">
-      <Args>
-        <Arg Type="INT" Entity="CHAR"/>
-        <Arg Type="INT" Entity="OBJECT"/>
-        <Arg Type="FLOAT" Desc="X Radius"/>
-        <Arg Type="FLOAT" Desc="Y Radius"/>
-        <Arg Type="FLOAT" Desc="Z Radius"/>
-        <Arg Type="INT" Desc="Bool"/>
-      </Args>
-    </Command>
-    <Command ID="0x475" Name="LOCATE_CHAR_ON_FOOT_OBJECT_3D" Supported="false">
+    <Command ID="0x474" Name="LOCATE_CHAR_ANY_MEANS_OBJECT_3D">
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
         <Arg Type="INT" Entity="OBJECT"/>
@@ -7382,7 +7372,17 @@
         <Arg Type="INT" Desc="Bool"/>
       </Args>
     </Command>
-    <Command ID="0x476" Name="LOCATE_CHAR_IN_CAR_OBJECT_3D" Supported="false">
+    <Command ID="0x475" Name="LOCATE_CHAR_ON_FOOT_OBJECT_3D">
+      <Args>
+        <Arg Type="INT" Entity="CHAR"/>
+        <Arg Type="INT" Entity="OBJECT"/>
+        <Arg Type="FLOAT" Desc="X Radius"/>
+        <Arg Type="FLOAT" Desc="Y Radius"/>
+        <Arg Type="FLOAT" Desc="Z Radius"/>
+        <Arg Type="INT" Desc="Bool"/>
+      </Args>
+    </Command>
+    <Command ID="0x476" Name="LOCATE_CHAR_IN_CAR_OBJECT_3D">
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
         <Arg Type="INT" Entity="OBJECT"/>
@@ -7392,11 +7392,10 @@
         <Arg Type="INT" Desc="Bool"/>
       </Args>
     </Command>
-    <Command ID="0x477" Name="SET_CAR_TEMP_ACTION">
+    <Command ID="0x477" Name="SET_CAR_HANDBRAKE_TURN_LEFT">
       <Args>
         <Arg Type="INT" Entity="CAR"/>
-        <Arg Type="INT" Enum="TEMPACT"/>
-        <Arg Type="INT" Desc="Time"/>
+        <Arg Type="INT"/>
       </Args>
     </Command>
     <Command ID="0x478" Name="SET_CAR_HANDBRAKE_TURN_RIGHT">

--- a/config/gtasa/cleo.xml
+++ b/config/gtasa/cleo.xml
@@ -280,7 +280,7 @@
     <Command ID="0xa9a" Name="OPEN_FILE" Hash="0xd4269fc0">
       <Args>
         <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
-        <Arg Type="INT"/>
+        <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
         <Arg Type="INT" Out="true" Entity="FILE"/>
       </Args>
     </Command>

--- a/config/gtasa/commandline.txt
+++ b/config/gtasa/commandline.txt
@@ -12,6 +12,7 @@
 -fswitch
 -farrays
 -fconst
+-fno-ifnot
 -fscope-then-label
 -funderscore-idents
 -fstreamed-scripts

--- a/config/gtasa/commands.xml
+++ b/config/gtasa/commands.xml
@@ -8881,8 +8881,8 @@
       <Args>
         <Arg Type="INT" Entity="CHAR"/>
         <Arg Type="INT" Entity="CAR"/>
-        <Arg Type="INT"/>
         <Arg Type="INT" Desc="Time"/>
+        <Arg Type="INT"/>
       </Args>
     </Command>
     <Command ID="0x5cb" Name="TASK_ENTER_CAR_AS_DRIVER">

--- a/config/gtavc/cleo.xml
+++ b/config/gtavc/cleo.xml
@@ -344,7 +344,7 @@
     <Command ID="0xa9a" Name="OPEN_FILE" Hash="0xd4269fc0">
       <Args>
         <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
-        <Arg Type="INT"/>
+        <Arg Type="STRING" AllowPointer="true" PreserveCase="true"/>
         <Arg Type="INT" Out="true" Entity="FILE"/>
       </Args>
     </Command>

--- a/config/gtavc/commandline.txt
+++ b/config/gtavc/commandline.txt
@@ -7,6 +7,7 @@
 -fno-switch
 -fno-arrays
 -fno-const
+-fno-ifnot
 -fscope-then-label
 -fno-underscore-idents
 -fno-streamed-scripts

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -55,6 +55,7 @@ Commands::Commands(transparent_set<Command>&& commands_,
     this->cleo_return                   = find_command("CLEO_RETURN");
     this->terminate_this_custom_script  = find_command("TERMINATE_THIS_CUSTOM_SCRIPT");
     this->goto_                          = find_command("GOTO");
+    this->goto_if_true                  = find_command("GOTO_IF_TRUE");
     this->goto_if_false                 = find_command("GOTO_IF_FALSE");
     this->andor                         = find_command("ANDOR");
     this->save_string_to_debug_file     = find_command("SAVE_STRING_TO_DEBUG_FILE");

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -358,6 +358,7 @@ public:
     optional<const Command&> cleo_return;
     optional<const Command&> terminate_this_custom_script;
     optional<const Command&> goto_;
+    optional<const Command&> goto_if_true;
     optional<const Command&> goto_if_false;
     optional<const Command&> andor;
     optional<const Command&> register_streamed_script_internal;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -147,10 +147,16 @@ void CompilerContext::compile_statement(const SyntaxTree& node, bool not_flag)
             compile_scope(node);
             break;
         case NodeType::IF:
-            compile_if(node);
+            compile_if(node, false);
+            break;
+        case NodeType::IFNOT:
+            compile_if(node, true);
             break;
         case NodeType::WHILE:
-            compile_while(node);
+            compile_while(node, false);
+            break;
+        case NodeType::WHILENOT:
+            compile_while(node, true);
             break;
         case NodeType::REPEAT:
             compile_repeat(node);
@@ -200,13 +206,13 @@ void CompilerContext::compile_scope(const SyntaxTree& scope_node)
     compile_statements(scope_node.child(0));
 }
 
-void CompilerContext::compile_if(const SyntaxTree& if_node)
+void CompilerContext::compile_if(const SyntaxTree& if_node, bool not_flag)
 {
     if(if_node.child_count() == 3) // [conds, case_true, else]
     {
         auto else_ptr = make_internal_label();
         auto end_ptr  = make_internal_label();
-        compile_conditions(if_node.child(0), else_ptr);
+        compile_conditions(if_node.child(0), else_ptr, not_flag);
         compile_statements(if_node.child(1));
         compile_command(*this->commands.goto_, { end_ptr });
         compile_label(else_ptr);
@@ -216,13 +222,13 @@ void CompilerContext::compile_if(const SyntaxTree& if_node)
     else // [conds, case_true]
     {
         auto end_ptr = make_internal_label();
-        compile_conditions(if_node.child(0), end_ptr);
+        compile_conditions(if_node.child(0), end_ptr, not_flag);
         compile_statements(if_node.child(1));
         compile_label(end_ptr);
     }
 }
 
-void CompilerContext::compile_while(const SyntaxTree& while_node)
+void CompilerContext::compile_while(const SyntaxTree& while_node, bool not_flag)
 {
     auto beg_ptr = make_internal_label();
     auto end_ptr = make_internal_label();
@@ -230,7 +236,7 @@ void CompilerContext::compile_while(const SyntaxTree& while_node)
     loop_stack.emplace_back(LoopInfo { beg_ptr, end_ptr });
 
     compile_label(beg_ptr);
-    compile_conditions(while_node.child(0), end_ptr);
+    compile_conditions(while_node.child(0), end_ptr, not_flag);
     compile_statements(while_node.child(1));
     compile_command(*this->commands.goto_, { beg_ptr });
     compile_label(end_ptr);
@@ -598,7 +604,7 @@ void CompilerContext::compile_condition(const SyntaxTree& node, bool not_flag)
     }
 }
 
-void CompilerContext::compile_conditions(const SyntaxTree& conds_node, const shared_ptr<Label>& else_ptr)
+void CompilerContext::compile_conditions(const SyntaxTree& conds_node, const shared_ptr<Label>& else_ptr, bool not_flag)
 {
     auto compile_multi_andor = [this](const auto& conds_node, size_t op)
     {
@@ -631,7 +637,7 @@ void CompilerContext::compile_conditions(const SyntaxTree& conds_node, const sha
             Unreachable();
     }
 
-    compile_command(*this->commands.goto_if_false, { else_ptr });
+    compile_command(not_flag ? *this->commands.goto_if_true : *this->commands.goto_if_false, { else_ptr });
 }
 
 auto CompilerContext::get_args(const Command& command, const std::vector<any>& params) -> ArgList

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -147,16 +147,16 @@ void CompilerContext::compile_statement(const SyntaxTree& node, bool not_flag)
             compile_scope(node);
             break;
         case NodeType::IF:
-            compile_if(node, false);
+            compile_if(node);
             break;
         case NodeType::IFNOT:
-            compile_if(node, true);
+            compile_ifnot(node);
             break;
         case NodeType::WHILE:
-            compile_while(node, false);
+            compile_while(node);
             break;
         case NodeType::WHILENOT:
-            compile_while(node, true);
+            compile_whilenot(node);
             break;
         case NodeType::REPEAT:
             compile_repeat(node);
@@ -206,29 +206,77 @@ void CompilerContext::compile_scope(const SyntaxTree& scope_node)
     compile_statements(scope_node.child(0));
 }
 
-void CompilerContext::compile_if(const SyntaxTree& if_node, bool not_flag)
+void CompilerContext::compile_if(const SyntaxTree& if_node)
 {
+    auto end_ptr = make_internal_label();
+
     if(if_node.child_count() == 3) // [conds, case_true, else]
     {
         auto else_ptr = make_internal_label();
-        auto end_ptr  = make_internal_label();
-        compile_conditions(if_node.child(0), else_ptr, not_flag);
+        compile_conditions(if_node.child(0), else_ptr, false);
         compile_statements(if_node.child(1));
         compile_command(*this->commands.goto_, { end_ptr });
         compile_label(else_ptr);
         compile_statements(if_node.child(2));
-        compile_label(end_ptr);
     }
     else // [conds, case_true]
     {
-        auto end_ptr = make_internal_label();
-        compile_conditions(if_node.child(0), end_ptr, not_flag);
+        compile_conditions(if_node.child(0), end_ptr, false);
         compile_statements(if_node.child(1));
-        compile_label(end_ptr);
     }
+
+    compile_label(end_ptr);
 }
 
-void CompilerContext::compile_while(const SyntaxTree& while_node, bool not_flag)
+void CompilerContext::compile_ifnot(const SyntaxTree& ifnot_node)
+{
+    auto end_ptr = make_internal_label();
+
+    auto opt_goto_if_true = commands.goto_if_true;
+    if (opt_goto_if_true && opt_goto_if_true->supported)
+    {
+        // "Native" IFNOT using GOTO_IF_TRUE
+        if(ifnot_node.child_count() == 3) // [conds, case_false, else]
+        {
+            auto else_ptr = make_internal_label();
+            compile_conditions(ifnot_node.child(0), else_ptr, true);
+            compile_statements(ifnot_node.child(1));
+            compile_command(*this->commands.goto_, { end_ptr });
+            compile_label(else_ptr);
+            compile_statements(ifnot_node.child(2));
+        }
+        else // [conds, case_false]
+        {
+            compile_conditions(ifnot_node.child(0), end_ptr, true);
+            compile_statements(ifnot_node.child(1));
+        }
+    }
+    else
+    {
+        // "Emulated" IFNOT using extra gotos and reordered cases
+        if(ifnot_node.child_count() == 3) // [conds, case_false, else]
+        {
+            auto else_ptr = make_internal_label();
+            compile_conditions(ifnot_node.child(0), else_ptr, false);
+            compile_statements(ifnot_node.child(2));
+            compile_command(*this->commands.goto_, { end_ptr });
+            compile_label(else_ptr);
+            compile_statements(ifnot_node.child(1));
+        }
+        else // [conds, case_false]
+        {
+            auto then_ptr = make_internal_label();
+            compile_conditions(ifnot_node.child(0), then_ptr, false);
+            compile_command(*this->commands.goto_, { end_ptr });
+            compile_label(then_ptr);
+            compile_statements(ifnot_node.child(1));
+        }
+    }
+
+    compile_label(end_ptr);
+}
+
+void CompilerContext::compile_while(const SyntaxTree& while_node)
 {
     auto beg_ptr = make_internal_label();
     auto end_ptr = make_internal_label();
@@ -236,8 +284,39 @@ void CompilerContext::compile_while(const SyntaxTree& while_node, bool not_flag)
     loop_stack.emplace_back(LoopInfo { beg_ptr, end_ptr });
 
     compile_label(beg_ptr);
-    compile_conditions(while_node.child(0), end_ptr, not_flag);
+    compile_conditions(while_node.child(0), end_ptr, false);
     compile_statements(while_node.child(1));
+    compile_command(*this->commands.goto_, { beg_ptr });
+    compile_label(end_ptr);
+
+    loop_stack.pop_back();
+}
+
+void CompilerContext::compile_whilenot(const SyntaxTree& whilenot_node)
+{
+    auto beg_ptr = make_internal_label();
+    auto end_ptr = make_internal_label();
+
+    loop_stack.emplace_back(LoopInfo { beg_ptr, end_ptr });
+
+    compile_label(beg_ptr);
+
+    auto opt_goto_if_true = commands.goto_if_true;
+    if (opt_goto_if_true && opt_goto_if_true->supported)
+    {
+        // "Native" WHILENOT using GOTO_IF_TRUE
+        compile_conditions(whilenot_node.child(0), end_ptr, true);
+    }
+    else
+    {
+        // "Emulated" WHILENOT using extra gotos
+        auto then_ptr = make_internal_label();
+        compile_conditions(whilenot_node.child(0), then_ptr, false);
+        compile_command(*this->commands.goto_, { end_ptr });
+        compile_label(then_ptr);
+    }
+
+    compile_statements(whilenot_node.child(1));
     compile_command(*this->commands.goto_, { beg_ptr });
     compile_label(end_ptr);
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -222,9 +222,9 @@ private:
 
     void compile_scope(const SyntaxTree& scope_node);
 
-    void compile_if(const SyntaxTree& if_node);
+    void compile_if(const SyntaxTree& if_node, bool not_flag);
 
-    void compile_while(const SyntaxTree& while_node);
+    void compile_while(const SyntaxTree& while_node, bool not_flag);
 
     void compile_repeat(const SyntaxTree& repeat_node);
 
@@ -248,7 +248,7 @@ private:
 
     void compile_condition(const SyntaxTree& node, bool not_flag = false);
 
-    void compile_conditions(const SyntaxTree& conds_node, const shared_ptr<Label>& else_ptr);
+    void compile_conditions(const SyntaxTree& conds_node, const shared_ptr<Label>& else_ptr, bool not_flag);
 
     void compile_dump(const SyntaxTree& node);
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -222,9 +222,11 @@ private:
 
     void compile_scope(const SyntaxTree& scope_node);
 
-    void compile_if(const SyntaxTree& if_node, bool not_flag);
+    void compile_if(const SyntaxTree& if_node);
+    void compile_ifnot(const SyntaxTree& ifnot_node);
 
-    void compile_while(const SyntaxTree& while_node, bool not_flag);
+    void compile_while(const SyntaxTree& while_node);
+    void compile_whilenot(const SyntaxTree& whilenot_node);
 
     void compile_repeat(const SyntaxTree& repeat_node);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ Language Options:
   -fswitch                 Enables the SWITCH statement.
   -farrays                 Enables the use of arrays.
   -fconst                  Enables the use of CONST_INT and CONST_FLOAT.
+  -fifnot                  Enables the use of IFNOT and WHILENOT.
   -ftext-label-vars        Enables VAR_TEXT_LABEL and VAR_TEXT_LABEL16.
   -fskip-cutscene          Enables the use of SKIP_CUTSCENE_START.
   -fscript-name-check      Checks for duplicate SCRIPT_NAMEs.
@@ -296,6 +297,10 @@ bool parse_args(char**& argv, fs::path& input, fs::path& output, DataInfo& data,
             else if(optflag(argv, "-fswitch", &flag))
             {
                 options.fswitch = flag;
+            }
+            else if(optflag(argv, "-fifnot", &flag))
+            {
+                options.fifnot = flag;
             }
             else if(optflag(argv, "-fbreak-continue", nullptr))
             {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -48,10 +48,12 @@ enum class Token
     OR,
     
     IF,
+    IFNOT,
     ELSE,
     ENDIF,
 
     WHILE,
+    WHILENOT,
     ENDWHILE,
 
     REPEAT,
@@ -124,8 +126,10 @@ enum class NodeType
     OR,
 
     IF,
+    IFNOT,
     ELSE,
     WHILE,
+    WHILENOT,
     REPEAT,
     SWITCH,
     CASE,

--- a/src/parser_lexer.cpp
+++ b/src/parser_lexer.cpp
@@ -626,9 +626,19 @@ static void lex_line(LexerContext& lexer, const char* source_data, size_t begin_
             it = push_token(*opt_first_token, Token::IF);
             had_keycommand = true;
         }
+        else if(lex_istokeq(*opt_first_token, "IFNOT"))
+        {
+            it = push_token(*opt_first_token, Token::IFNOT);
+            had_keycommand = true;
+        }
         else if(lex_istokeq(*opt_first_token, "WHILE"))
         {
             it = push_token(*opt_first_token, Token::WHILE);
+            had_keycommand = true;
+        }
+        else if(lex_istokeq(*opt_first_token, "WHILENOT"))
+        {
+            it = push_token(*opt_first_token, Token::WHILENOT);
             had_keycommand = true;
         }
     }

--- a/src/parser_syntax.cpp
+++ b/src/parser_syntax.cpp
@@ -986,18 +986,9 @@ static ParserResult parse_condition_list(ParserContext& parser, token_iterator b
         return std::make_pair(it, std::move(state));
 }
 
-
-/*
-    whileStatement
-        :	WHILE conditionList
-                statementList
-            ENDWHILE newLine
-        ->  ^(WHILE conditionList statementList)
-        ;
-*/
-static ParserResult parse_while_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+static ParserResult parse_while_statement_internal(ParserContext& parser, token_iterator begin, token_iterator end, Token token_type, NodeType node_type)
 {
-    if(begin != end && begin->type == Token::WHILE)
+    if(begin != end && begin->type == token_type)
     {
         ParserState state = ParserSuccess(nullptr);
         ParserState conditions, statements;
@@ -1020,7 +1011,7 @@ static ParserResult parse_while_statement(ParserContext& parser, token_iterator 
 
         if(is<ParserSuccess>(state))
         {
-            shared_ptr<SyntaxTree> tree(new SyntaxTree(NodeType::WHILE, parser.instream, *begin));
+            shared_ptr<SyntaxTree> tree(new SyntaxTree(node_type, parser.instream, *begin));
             tree->add_child(get<ParserSuccess>(conditions).tree);
             tree->add_child(get<ParserSuccess>(statements).tree);
             return std::make_pair(it, ParserSuccess(std::move(tree)));
@@ -1031,6 +1022,32 @@ static ParserResult parse_while_statement(ParserContext& parser, token_iterator 
         }
     }
     return std::make_pair(end, make_error(ParserStatus::GiveUp, begin));
+}
+
+/*
+    whileStatement
+        :	WHILE conditionList
+                statementList
+            ENDWHILE newLine
+        ->  ^(WHILE conditionList statementList)
+        ;
+*/
+static ParserResult parse_while_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+{
+    return parse_while_statement_internal(parser, begin, end, Token::WHILE, NodeType::WHILE);
+}
+
+/*
+    whilenotStatement
+        :	WHILENOT conditionList
+                statementList
+            ENDWHILE newLine
+        ->  ^(WHILENOT conditionList statementList)
+        ;
+*/
+static ParserResult parse_whilenot_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+{
+    return parse_while_statement_internal(parser, begin, end, Token::WHILENOT, NodeType::WHILENOT);
 }
 
 /*
@@ -1187,19 +1204,9 @@ static ParserResult parse_switch_statement(ParserContext& parser, token_iterator
     }
 }
 
-/*
-    ifStatement
-        :	IF conditionList
-                statIf=statementList
-            (ELSE newLine
-                statElse=statementList)?
-            ENDIF newLine
-        ->	^(IF conditionList $statIf ^(ELSE $statElse)?)
-        ;
-*/
-static ParserResult parse_if_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+static ParserResult parse_if_statement_internal(ParserContext& parser, token_iterator begin, token_iterator end, Token token_type, NodeType node_type)
 {
-    if(begin != end && begin->type == Token::IF)
+    if(begin != end && begin->type == token_type)
     {
         ParserState state = ParserSuccess(nullptr);
         ParserState           conditions;
@@ -1238,7 +1245,7 @@ static ParserResult parse_if_statement(ParserContext& parser, token_iterator beg
 
         if(is<ParserSuccess>(state))
         {
-            shared_ptr<SyntaxTree> tree(new SyntaxTree(NodeType::IF, parser.instream, *begin));
+            shared_ptr<SyntaxTree> tree(new SyntaxTree(node_type, parser.instream, *begin));
 
             tree->add_child(get<ParserSuccess>(conditions).tree);
             tree->add_child(get<ParserSuccess>(body_true).tree);
@@ -1258,6 +1265,36 @@ static ParserResult parse_if_statement(ParserContext& parser, token_iterator beg
         }
     }
     return std::make_pair(end, make_error(ParserStatus::GiveUp, begin));
+}
+
+/*
+    ifStatement
+        :	IF conditionList
+                statIf=statementList
+            (ELSE newLine
+                statElse=statementList)?
+            ENDIF newLine
+        ->	^(IF conditionList $statIf ^(ELSE $statElse)?)
+        ;
+*/
+static ParserResult parse_if_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+{
+    return parse_if_statement_internal(parser, begin, end, Token::IF, NodeType::IF);
+}
+
+/*
+    ifnotStatement
+        :	IFNOT conditionList
+                statIf=statementList
+            (ELSE newLine
+                statElse=statementList)?
+            ENDIF newLine
+        ->	^(IFNOT conditionList $statIf ^(ELSE $statElse)?)
+        ;
+*/
+static ParserResult parse_ifnot_statement(ParserContext& parser, token_iterator begin, token_iterator end)
+{
+    return parse_if_statement_internal(parser, begin, end, Token::IFNOT, NodeType::IFNOT);
 }
 
 /*
@@ -1339,7 +1376,9 @@ static ParserResult parse_statement(ParserContext& parser, token_iterator begin,
     auto result = parse_oneof(parser, begin, end,
                               parse_scope_statement,
                               parse_if_statement,
+                              parse_ifnot_statement,
                               parse_while_statement,
+                              parse_whilenot_statement,
                               parse_repeat_statement,
                               parse_switch_statement,
                               parse_dump_statement,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -88,6 +88,7 @@ public:
     bool entity_tracking = true;
     bool script_name_check = true;
     bool fswitch = false;
+    bool fifnot = false;
     bool allow_break_continue = false;
     bool scope_then_label = false;
     bool farrays = false;

--- a/src/symtable.cpp
+++ b/src/symtable.cpp
@@ -805,6 +805,10 @@ void Script::annotate_tree(const SymTable& symbols, ProgramContext& program)
                 return false;
             }
 
+            case NodeType::IFNOT:
+                if(!program.opt.fifnot)
+                    program.error(node, "IFNOT not supported [-fifnot]");
+                [[fallthrough]];
             case NodeType::IF:
             {
                 traverse_condition_list(node.child(0));
@@ -817,6 +821,10 @@ void Script::annotate_tree(const SymTable& symbols, ProgramContext& program)
                 return false;
             }
 
+            case NodeType::WHILENOT:
+                if(!program.opt.fifnot)
+                    program.error(node, "WHILENOT not supported [-fifnot]");
+                [[fallthrough]];
             case NodeType::WHILE:
             {
                 traverse_condition_list(node.child(0));


### PR DESCRIPTION
`IFNOT` and `WHILENOT` seem useless if you're writing the script by the book, but they actually come in handy for pseudo-functions.

This won't work:
```
IF NOT GOSUB my_complex_check
   PRINT_STRING_NOW "Complex check failed!"
ENDIF
```

This **will** work:
```
IFNOT GOSUB my_complex_check
   PRINT_STRING_NOW "Complex check failed!"
ENDIF
```

I gated it off behind `-fifnot` that is enabled by default in GTA III, and disabled in Vice City and San Andreas. I will certainly find use for this in Upstate.

Also corrected `SET_GARAGE` in GTA III. Vice City was already correct.

Fixes #30. Fixes #142. Fixes #125.